### PR TITLE
lock version to 1.2.475

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        with: 
+          version: 1.2.475
 
       - name: Render and Publish
         uses: quarto-dev/quarto-actions/publish@v2


### PR DESCRIPTION
- lock version to 1.2.475. Untuk update ke 1.3.x harus dicoba terlebih dahulu. Kemungkinan setelah rilisnya feidlambda 0.4.0